### PR TITLE
Small fixes

### DIFF
--- a/BT-lang/Runtime/BTL-BinEval.cs
+++ b/BT-lang/Runtime/BTL-BinEval.cs
@@ -63,6 +63,7 @@ public class BinEval : Elk.Basic.Runtime.BinEval{
 
     status ToStatus(object arg)
     => arg is status s ? s : arg is bool b ? (status)b
+    : arg is null ? fail  // TODO #25
     : throw new Ex($"Don't know how to convert {arg} to status");
 
     object EvalFloat(string op, float X, float Y){

--- a/BT-lang/Runtime/BTL.cs
+++ b/BT-lang/Runtime/BTL.cs
@@ -29,6 +29,10 @@ public class BTL : MonoBehaviour, LogSource{
         }
     }
 
+    void OnDisable(){
+        log = "DISABLED";
+    }
+
     object Parse(string path){
         var src = Resources.Load<TextAsset>(path).text;
         if(src.StartsWith(BTLScriptChecker.Shebang))


### PR DESCRIPTION
- Display "DISABLED" in log window when BT is disabled
- In `x || y` and `x && y`, if left hand is a status and right hand is null, promote null to `status.fail` (transitional)