### PR TITLE
Enable memory driven behaviors

### DIFF
--- a/BT-lang/Runtime/BTLContextFactory.cs
+++ b/BT-lang/Runtime/BTLContextFactory.cs
@@ -1,3 +1,4 @@
+using Elk;
 using Elk.Basic;
 using FuncDef = Elk.Basic.Graph.FuncDef;
 using Active.Core;
@@ -5,11 +6,13 @@ using Active.Core;
 namespace Activ.BTL{
 public static class BTLContextFactory{
 
-    public static Context Create(object program,
-                                 params object[] externals){
+    public static Context Create(
+        object program, History history, params object[] externals
+    ){
         var cx = new Context(){
             modules = new FuncDef[][]{ (FuncDef[])program },
             externals = externals,
+            history = history
         };
         cx.graph.returnValueFormatter = x => {
             var str = x?.ToString() ?? "∅";

--- a/BT-lang/Runtime/BTLHistory.cs
+++ b/BT-lang/Runtime/BTLHistory.cs
@@ -1,0 +1,17 @@
+using Active.Core.Details;
+
+namespace Activ.BTL{
+public readonly struct BTLHistory : Elk.History{
+
+    readonly History history;
+
+    public BTLHistory(History history)
+    => this.history = history;
+
+    public bool Did(string action)
+    => history.Contains(action);
+
+    public bool Did(string action, string since, bool strict)
+    => history.Contains(action, since, strict);
+
+}}

--- a/BT-lang/Runtime/BTLHistory.cs.meta
+++ b/BT-lang/Runtime/BTLHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50c897e98737f5a47a9f394f05f9d483
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/API.cs
+++ b/Elk/Runtime/API.cs
@@ -50,6 +50,11 @@ public interface Parser{
     object Parse(Sequence tokens);
 }
 
+public interface History{
+    bool Did(string action);
+    bool Did(string action, string since, bool strict);
+}
+
 public interface Validator{
     void Validate(object program, bool allowSubPrograms);
 }

--- a/Elk/Runtime/Basic/Context.cs
+++ b/Elk/Runtime/Basic/Context.cs
@@ -10,6 +10,7 @@ public class Context{
     public IEnumerable<FuncDef[]> modules;
     public IEnumerable<object> externals;
     public CallGraph graph;
+    public Elk.History history;
 
     public Context(){
         argumentStack = new Stack<ArgMap>();

--- a/Elk/Runtime/Basic/Graph/Invocation.cs
+++ b/Elk/Runtime/Basic/Graph/Invocation.cs
@@ -23,6 +23,7 @@ public class Invocation : Expression{
         if(arguments == null) return $"{name}()";
         var @out = new StringBuilder();
         @out.Append(name);
+        @out.Append("(");
         for(int i = 0; i < arguments.Length; i++){
             @out.Append(
                 $"{arguments[i]}" +

--- a/Elk/Runtime/Basic/Graph/Recall.cs
+++ b/Elk/Runtime/Basic/Graph/Recall.cs
@@ -1,0 +1,20 @@
+using S = System.String;
+using Elk.Bindings.CSharp;
+
+namespace Elk.Basic.Graph{
+public class Recall : Expression{
+
+    public readonly Invocation action;
+    public readonly Invocation since;
+    public readonly bool strict;
+
+    public Recall(Invocation action, Invocation since, bool strict){
+        if(action == null) throw new ParsingException("action is undefined");
+        this.action = action;
+        this.since = since;
+        this.strict = strict;
+    }
+
+    override public S ToString() => $"(did [{action}] since [{since}])";
+
+}}

--- a/Elk/Runtime/Basic/Graph/Recall.cs.meta
+++ b/Elk/Runtime/Basic/Graph/Recall.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05a856f0ba1cb7a438b546dc65a80786
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser-Details/RecallRule.cs
+++ b/Elk/Runtime/Basic/Parser-Details/RecallRule.cs
@@ -1,0 +1,31 @@
+using Elk.Util;
+using Elk.Basic.Graph;
+
+namespace Elk.Basic{
+public partial class Parser : Elk.Parser{
+public class RecallRule : LocalRule{
+
+    override public void Process(Sequence vec, int i){
+        var op0  = vec.AsString(i);
+        var arg0 = vec.Get<Invocation>(i + 1);
+        if(op0 != "did" || arg0 == null) return;
+        var op1 = vec.AsString(i + 2);
+        if(op1 != "since"){
+            vec.Replace(i, 2,
+                        new Recall(arg0, null, strict: false), this);
+        }else{
+            var arg1 = vec.Get<Invocation>(i + 3);
+            if(arg1 == null) return;
+            var op2 = vec.AsString(i + 4);
+            var n = 4;
+            bool strict = false;
+            if( op2 == "!"){ strict = true; n = 5; }
+            vec.Replace(i, n,
+                        new Recall(arg0, arg1, strict), this);
+        }
+    }
+
+    override public string ToString()
+    => $"RecallRule";
+
+}}}

--- a/Elk/Runtime/Basic/Parser-Details/RecallRule.cs.meta
+++ b/Elk/Runtime/Basic/Parser-Details/RecallRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03efb67b79381b44697533fe731e212a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser.cs
+++ b/Elk/Runtime/Basic/Parser.cs
@@ -10,7 +10,7 @@ using static Elk.Basic.Parser.RuleSet;
 namespace Elk.Basic{
 public partial class Parser : Elk.Parser{
 
-    public static bool showErrorDetails = false;
+    public static bool showErrorDetails = true;
     Rule[] rules;
     public Action log;
 
@@ -18,6 +18,7 @@ public partial class Parser : Elk.Parser{
 
     public Parser(string funcPreamble) => rules = new Rule[]{
         Rst( new FuncRule(), new FuncPrecursor(funcPreamble)),
+        Rst( new RecallRule() ),
         Rst( ".", new InvocationRule()),
         Una("! ~ ++ -- + -"),
         Bin("* / %"),

--- a/Elk/Runtime/Basic/Runner-Details/InvocationEval.cs
+++ b/Elk/Runtime/Basic/Runner-Details/InvocationEval.cs
@@ -1,9 +1,8 @@
 using Ex = System.Exception;
-using UnityEngine;
 using Elk.Util;
+using Elk.Basic.Runtime;
 using Elk.Bindings.CSharp;
 using Elk.Basic.Graph;
-using Elk.Basic.Runtime;
 
 namespace Elk.Basic{
 public class InvocationEval{
@@ -16,11 +15,21 @@ public class InvocationEval{
         return @out;
     }
 
+    // PROVISIONAL - evaluate invocation arguments, then return
+    // the matching stack entry, without a return value
+    public string Recall(Invocation ι, Runner ρ, Context cx){
+        if(ι == null) return null;
+        ρ.EvalArgs(ι.arguments, @out: ι.values, cx);
+        return ι.name + ι.values.NeatFormat();
+    }
+
     public object DoEval(Invocation ι, Runner ρ, Context cx){
         if(ι.binding == null){
             ι.binding =  cx.modules  .Bind(ι, ρ, cx)
                       ?? cx.externals.Bind(ι.name, ι.values);
         }
+        InvocationBinding binding = (InvocationBinding)ι.binding;
+        if(binding == null) throw new Ex($"`{ι}` not found");
         return ((InvocationBinding)ι.binding).Eval(ι, ρ, cx);
     }
 

--- a/Elk/Runtime/Basic/Runner-Details/RecallEval.cs
+++ b/Elk/Runtime/Basic/Runner-Details/RecallEval.cs
@@ -1,0 +1,16 @@
+using Elk.Basic.Graph;
+using UnityEngine;
+
+namespace Elk.Basic{
+public class RecallEval{
+
+    public bool Eval(Recall r, Runner ρ, Context cx){
+        var action = "✓ " + ρ.inv.Recall(r.action, ρ, cx);
+        var since = ρ.inv.Recall(r.since, ρ, cx);
+        if(!string.IsNullOrEmpty(since)){
+            since = "✓ " + since;
+        }
+        return cx.history.Did(action, since, r.strict);
+    }
+
+}}

--- a/Elk/Runtime/Basic/Runner-Details/RecallEval.cs.meta
+++ b/Elk/Runtime/Basic/Runner-Details/RecallEval.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a88fd40b92329643aee3f108fb2cd54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Runner.cs
+++ b/Elk/Runtime/Basic/Runner.cs
@@ -10,6 +10,7 @@ public class Runner : Elk.Runner<Context>{
     public BinEval bin;
     public PropEval prp;
     public InvocationEval inv;
+    public RecallEval rec;
     public Func<object, bool> literal;
 
     public Runner(){
@@ -17,6 +18,7 @@ public class Runner : Elk.Runner<Context>{
         una = new UnaEval();
         prp = new PropEval();
         inv = new InvocationEval();
+        rec = new RecallEval();
         literal = IsLiteral;
     }
 
@@ -26,6 +28,7 @@ public class Runner : Elk.Runner<Context>{
             case UnaryExp  op: return una.Eval(op, this, cx);
             case string label: return prp.Eval(label, cx);
             case Invocation ι: return inv.Eval(ι, this, cx);
+            case Recall     r: return rec.Eval(r, this, cx);
             case object val when literal(val): return val;
             case null: return arg;
             default: throw new Ex($"Cannot evaluate {arg}");


### PR DESCRIPTION
See #34; may need extending to support external (such as project-custom) memory models; that said a custom memory model can leverage C# bridiging - acting on filtered (but still BT-lang native) records of what other BT-lang agents have been doing should be the next step