### PR TITLE
Parse comments

### DIFF
--- a/Elk/Runtime/Basic/CommentParser.cs
+++ b/Elk/Runtime/Basic/CommentParser.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Linq;
+using Elk.Util;
+
+namespace Elk.Basic{
+public class CommentParser{
+
+    const char n = '\n';
+    char κ = '#';
+
+    public CommentParser(){}
+
+    public CommentParser(char commentChar) => κ = commentChar;
+
+    public IEnumerable<xchar> Parse(string arg){
+        var characters = xchar.ToXChar(arg);
+        bool mute = false;
+        return from c in characters where !Mute(c, ref mute) select c;
+    }
+
+    bool Mute(char c, ref bool mute)
+    => c == κ ? (mute = true ) :
+       c == n ? (mute = false) : mute;
+
+}}

--- a/Elk/Runtime/Basic/CommentParser.cs.meta
+++ b/Elk/Runtime/Basic/CommentParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96560b42fe324bd4892c75871592e4d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser.cs
+++ b/Elk/Runtime/Basic/Parser.cs
@@ -50,7 +50,7 @@ public partial class Parser : Elk.Parser{
             var e = vector[i];
             if(e is FuncDef) continue;
             if(e is FuncDef[]) continue;
-            return $"error at line {vector.LineNumber(i)}";
+            return $"error at line {vector.LineNumber(i)}\n...";
         }
         return "Unknown error";
     }

--- a/Elk/Runtime/Basic/Tokenizer.cs
+++ b/Elk/Runtime/Basic/Tokenizer.cs
@@ -7,12 +7,17 @@ public class Tokenizer : Elk.Tokenizer{
 
     public char decimalDot = '.';
     public string doubleSymbols = "+-&|=";
+    CommentParser commentParser = new CommentParser();
 
     public Token[] Tokenize(string arg){
         StringBuilder word = new StringBuilder();
         List<Token> tokens = new List<Token>();
+        var xchars = commentParser.Parse(arg);
+        // NOTE - when a word is formed its line number is the same
+        // as the next character's.
         int line = 1;
-        foreach(char c in arg){
+        foreach(xchar c in xchars){
+            line = c.line;
             if(char.IsWhiteSpace(c) || char.IsControl(c)){
                 if(word.Length > 0){
                     tokens.Add(word, line);
@@ -25,15 +30,15 @@ public class Tokenizer : Elk.Tokenizer{
                 }
                 word.Append(c);
             }else{
-                // TODO in general I think one operator followed by another
-                // should be an error, however may want to support +=, -=, ...
-                if(!(Double(c, word) || IsDecimalDot(c, word) || IsArrowHead(c, word))){
+                // TODO sometimes one operator followed by another
+                // is an error, however... +=, -=, ...
+                if(!(Double(c, word) || IsDecimalDot(c, word)
+                                     || IsArrowHead(c, word))){
                     tokens.Add(word, line);
                     word = new StringBuilder();
                 }
                 word.Append(c);
             }
-            if(c.IsNewLine()) line++;
         }
         if(word.Length > 0) tokens.Add(word, line);
         return tokens.ToArray();

--- a/Elk/Runtime/Util/ArrayExt.cs
+++ b/Elk/Runtime/Util/ArrayExt.cs
@@ -36,4 +36,5 @@ public static class ArrayExt{
             default: return arg.ToString();
         }
     }
+
 }}

--- a/Elk/Runtime/Util/IEnumerableExt.cs
+++ b/Elk/Runtime/Util/IEnumerableExt.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elk.Util{
+public static class IEnumerableExt{
+
+    public static string Format(this IEnumerable<xchar> arg){
+        var x = new StringBuilder();
+        foreach(var c in arg) x.Append(c);
+        return x.ToString();
+    }
+
+}}

--- a/Elk/Runtime/Util/IEnumerableExt.cs.meta
+++ b/Elk/Runtime/Util/IEnumerableExt.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53370e44d48f1404abdcb0271353c83f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Util/xchar.cs
+++ b/Elk/Runtime/Util/xchar.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Elk.Util{
+public readonly struct xchar{
+
+    readonly char character;
+    public readonly int line;
+    public readonly int offset;
+
+    public xchar(char c, int line, int offset){
+        this.character = c;
+        this.line = line;
+        this.offset = offset;
+    }
+
+    public static implicit operator char(xchar self)
+    => self.character;
+
+    public static IEnumerable<xchar> ToXChar(string arg){
+        int line = 1, offset = 1;
+        return from c in arg
+               select CreateXChar(c, ref line, ref offset);
+    }
+
+    static xchar CreateXChar(char c, ref int line, ref int offset){
+        var @out = new xchar(c, line, offset);
+        if(c.IsNewLine()) { line++; offset = 1; }
+        else              { offset++; }
+        return @out;
+    }
+
+}}

--- a/Elk/Runtime/Util/xchar.cs
+++ b/Elk/Runtime/Util/xchar.cs
@@ -18,6 +18,8 @@ public readonly struct xchar{
     public static implicit operator char(xchar self)
     => self.character;
 
+    public bool IsNewLine() => character == '\n';
+
     public static IEnumerable<xchar> ToXChar(string arg){
         int line = 1, offset = 1;
         return from c in arg

--- a/Elk/Runtime/Util/xchar.cs.meta
+++ b/Elk/Runtime/Util/xchar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f22de731f10638c4cb2871fc6f7e8133
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Tests/CommentParserTest.cs
+++ b/Elk/Tests/CommentParserTest.cs
@@ -1,0 +1,16 @@
+//using System;
+using UnityEngine;
+using NUnit.Framework;
+using Elk.Basic;
+using Elk.Util;
+
+namespace Elk_Test{
+public class CommentParserTest{
+
+    [Test] public void TestParseComments(){
+        var parser = new CommentParser();
+        var @out = parser.Parse("Foo; # bar\n123");
+        Assert.That(@out.Format(), Is.EqualTo("Foo; \n123"));
+    }
+
+}}

--- a/Elk/Tests/CommentParserTest.cs.meta
+++ b/Elk/Tests/CommentParserTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7aca818ca5d5a234e86c85b961ab000c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Tests/XCharTest.cs
+++ b/Elk/Tests/XCharTest.cs
@@ -1,0 +1,19 @@
+//using UnityEngine;
+using System.Linq;
+using NUnit.Framework;
+using Elk.Util;
+
+namespace Elk_Test{
+public class XCharTest{
+
+    [Test] public void TestParseXCharArray(){
+        var str = "ab\ncd";
+        var z = xchar.ToXChar(str).ToArray();
+        Assert.That( z[0] == new xchar('a' , 1, 1) );
+        Assert.That( z[1] == new xchar('b' , 1, 2) );
+        Assert.That( z[2] == new xchar('\n', 1, 3) );
+        Assert.That( z[3] == new xchar('c' , 2, 1) );
+        Assert.That( z[4] == new xchar('d' , 2, 2) );
+    }
+
+}}

--- a/Elk/Tests/XCharTest.cs.meta
+++ b/Elk/Tests/XCharTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d088acd7a95cb14ca9f8fd6613cb3bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Support single char denoted comments; default is `#`
Closes #11 