### PR TITLE
Support memory driven behaviours

### DIFF
--- a/BT-lang/Runtime/BTLCog.cs
+++ b/BT-lang/Runtime/BTLCog.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Ex = System.Exception;
+using UnityEngine;
+using Active.Core;
+using Elk.Memory;
+using Context = Elk.Basic.Context;
+
+namespace Activ.BTL{
+public class BTLCog : Cog{
+
+    BTL owner;
+    public static List<BTLCog> instances = new List<BTLCog>(512);
+
+    public BTLCog(BTL owner){
+        this.owner = owner;
+        instances.Add(this);
+    }
+
+    public bool Did(
+        Call @event, Call since, bool strict, Context cx
+    ) => cx.record.Contains(@event, since, strict);
+
+    public void Commit(string call, object output, Record record){
+        if(output is status task && task.complete){
+            var time = Time.time;
+            record.Append("self." + call, Time.time);
+            foreach(var other in instances){
+                if(other == this) continue;
+                other.Notify(owner, call, time);
+            }
+        }
+    }
+
+    // NOTE - this just adds anything done by another agent to our
+    // record; normally filtering would be added for perception
+    void Notify(object agent, string call, float time){
+        owner.record.Append(
+            NameOf(agent, allowDefault: false) + "." + call,
+            time
+        );
+    }
+
+    public string NameOf(object agent, bool allowDefault){
+        switch(agent){
+            case GameObject go:
+                return go.name;
+            case Component co:
+                return co.gameObject.name;
+            case null:
+                return "self";
+            default:
+                return allowDefault ? null
+                : throw new Ex($"Name of {agent} is undefined");
+        }
+    }
+
+}}

--- a/BT-lang/Runtime/BTLCog.cs.meta
+++ b/BT-lang/Runtime/BTLCog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7656ebab8c85eec4db689040a15bbe7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BT-lang/Runtime/BTLContextFactory.cs
+++ b/BT-lang/Runtime/BTLContextFactory.cs
@@ -1,3 +1,4 @@
+using Elk;
 using Elk.Basic;
 using FuncDef = Elk.Basic.Graph.FuncDef;
 using Active.Core;
@@ -5,11 +6,14 @@ using Active.Core;
 namespace Activ.BTL{
 public static class BTLContextFactory{
 
-    public static Context Create(object program,
-                                 params object[] externals){
+    public static Context Create(
+        BTL owner, object program, params object[] externals
+    ){
         var cx = new Context(){
-            modules = new FuncDef[][]{ (FuncDef[])program },
+            modules   = new FuncDef[][]{ (FuncDef[])program },
             externals = externals,
+            record    = owner.record,
+            cog      = owner.cognition
         };
         cx.graph.returnValueFormatter = x => {
             var str = x?.ToString() ?? "∅";

--- a/Doc/BTL notes.md
+++ b/Doc/BTL notes.md
@@ -1,0 +1,34 @@
+# BTL notes
+
+## Language
+
+[PENDING]
+
+## Integration
+
+[PENDING]
+
+## Customize memory and apperception
+
+In BTL, the `did x` and `did x since y` forms can be used to test an agent's knowledge of past actions - including their own, or actions performed by other agents.
+
+By *default* agents are omniscient - every agent knows everything other agents have done. In production this is not desirable. Therefore providing your own cognition model is recommended.
+
+In general BTL takes care of the heavy lifting for you (all BT tasks are automatically recorded); a custom implementation hooks into automated task recording, and may accomplish any of the following and more:
+
+- Apperception driven filtering - when an agent did X, which other agents became aware of it?
+- How much do agents remember? For how long and how reliably? (simulate imperfect memory, both for optimization (storage) and realism)
+- Naming: what are other agents remembered as?
+- Plugging your own events into BTL records; such as apperception related (`cat.Spotted(mouse)`)
+- Record sharing / transacting (simulate knowledge exchange between agents).
+
+Two steps:
+
+- (1) Extend [BTLCog][../BT-lang/Runtime/BTLCog.cs] or implement the [Cog](../Elk/Runtime/Memory/Cog.cs) interface (see inline doc for details)
+- (2) Given a BTL component, assign `cognition`:
+
+cs
+```
+MyCog cog = new Cog();
+this.GetComponent<BTL>().cognition = cog;
+```

--- a/Doc/BTL notes.md.meta
+++ b/Doc/BTL notes.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a6c72313ac10451498b40b8bc4e6bbf9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Doc/ELK notes.md
+++ b/Doc/ELK notes.md
@@ -1,6 +1,6 @@
 # ELK notes
 
-## Adding a construct
+## Adding a construct [doc wip]
 
 As an example let's have a look at the work needed to add unary operator support.
 

--- a/Elk/Runtime/Basic/CallGraph.cs
+++ b/Elk/Runtime/Basic/CallGraph.cs
@@ -20,6 +20,8 @@ public class CallGraph{
         stack.Push(node);
     }
 
+    public string Peek() => stack.Peek().info;
+
     public void Pop(object returnValue){
         var str = returnValueFormatter?.Invoke(returnValue)
                   ?? returnValue?.ToString() ?? "null";

--- a/Elk/Runtime/Basic/Context.cs
+++ b/Elk/Runtime/Basic/Context.cs
@@ -10,6 +10,8 @@ public class Context{
     public IEnumerable<FuncDef[]> modules;
     public IEnumerable<object> externals;
     public CallGraph graph;
+    public Elk.Memory.Record record;
+    public Elk.Memory.Cog cog;
 
     public Context(){
         argumentStack = new Stack<ArgMap>();
@@ -20,11 +22,20 @@ public class Context{
     => argumentStack.Peek()[key];
 
     public bool HasKey(string name){
+        if(argumentStack.Count == 0) return false;
         var map = argumentStack.Peek();
         return map.ContainsKey(name);
     }
 
-    public void Push(string[] parameters, object[] arguments){
+    public void StackPush(string arg) => graph.Push(arg);
+
+    public void StackPop(object value){
+        var callInfo = graph.Peek();
+        cog.Commit(callInfo, value, record);
+        graph.Pop(value);
+    }
+
+    public void PushArguments(string[] parameters, object[] arguments){
         var map = new ArgMap();
         var len = parameters?.Length ?? 0;
         for(int i = 0; i < len; i++){
@@ -33,6 +44,6 @@ public class Context{
         argumentStack.Push(map);
     }
 
-    public void Pop() => argumentStack.Pop();
+    public void PopArguments() => argumentStack.Pop();
 
 }}

--- a/Elk/Runtime/Basic/Graph/Invocation.cs
+++ b/Elk/Runtime/Basic/Graph/Invocation.cs
@@ -23,6 +23,7 @@ public class Invocation : Expression{
         if(arguments == null) return $"{name}()";
         var @out = new StringBuilder();
         @out.Append(name);
+        @out.Append("(");
         for(int i = 0; i < arguments.Length; i++){
             @out.Append(
                 $"{arguments[i]}" +

--- a/Elk/Runtime/Basic/Graph/Recall.cs
+++ b/Elk/Runtime/Basic/Graph/Recall.cs
@@ -1,0 +1,21 @@
+using S = System.String;
+using Elk.Bindings.CSharp;
+
+namespace Elk.Basic.Graph{
+public class Recall : Expression{
+
+    public readonly Expression action;
+    public readonly Expression since;
+    public readonly bool strict;
+
+    public Recall(Expression action, Expression since, bool strict){
+        this.action = action;
+        this.since = since;
+        this.strict = strict;
+    }
+
+    override public S ToString()
+    => since != null ? $"(did [{action}] since [{since}])"
+                     : $"(did [{action}])";
+
+}}

--- a/Elk/Runtime/Basic/Graph/Recall.cs.meta
+++ b/Elk/Runtime/Basic/Graph/Recall.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05a856f0ba1cb7a438b546dc65a80786
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser-Details/AccessRule.cs
+++ b/Elk/Runtime/Basic/Parser-Details/AccessRule.cs
@@ -1,0 +1,17 @@
+using Elk.Util;
+using Elk.Basic.Graph;
+
+namespace Elk.Basic{
+public partial class Parser : Elk.Parser{
+public class AccessRule : BinaryRule{
+
+    public AccessRule() : base(".") {}
+
+    // NOTE: checks for an opening parens, otherwise (x.y)
+    // may conflict with invocation exp
+    // 0   1  2  3
+    // foo . bar (
+    override protected bool Validate(Sequence vec, int i)
+    => vec.AsString(i + 3) != "(";
+
+}}}

--- a/Elk/Runtime/Basic/Parser-Details/AccessRule.cs.meta
+++ b/Elk/Runtime/Basic/Parser-Details/AccessRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebc5d95f6bfe00142966b47d48639475
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser-Details/BinaryRule.cs
+++ b/Elk/Runtime/Basic/Parser-Details/BinaryRule.cs
@@ -10,6 +10,7 @@ public class BinaryRule : LocalRule{
     public BinaryRule(object op) => this.op = op.ToString();
 
     override public void Process(Sequence vec, int i){
+        if(!Validate(vec, i)) return;
         var x  = vec.Get(i);
         var op = vec.AsString(i + 1);
         var y  = vec.Get(i + 2);
@@ -17,6 +18,8 @@ public class BinaryRule : LocalRule{
         if(op != this.op || y == null) return;
         vec.Replace(i, 3, new BinaryExp( vec[i], op, vec[i+2]), this);
     }
+
+    protected virtual bool Validate(Sequence vec, int i) => true;
 
     override public string ToString()
     => $"BinaryRule({op})";

--- a/Elk/Runtime/Basic/Parser-Details/RecallRule.cs
+++ b/Elk/Runtime/Basic/Parser-Details/RecallRule.cs
@@ -1,0 +1,59 @@
+using Elk.Util;
+using Elk.Basic.Graph;
+using UnityEngine;
+
+namespace Elk.Basic{
+public partial class Parser : Elk.Parser{
+public class RecallRule : LocalRule{
+
+    override public void Process(Sequence vec, int i){
+        var i0 = i;
+        var op0  = vec.AsString(i++);
+        var arg0 = vec.Get<Expression>(i++);
+        if(!ValidateOperand(arg0)) return;
+        if(op0 != "did" || arg0 == null){
+            //ebug.Log("'did' not found");
+            return;
+        }
+        var op1 = vec.AsString(i);
+        if(op1 != "since"){
+            //ebug.Log("Short form because 'since' not found");
+            vec.Replace(
+                i0, i - i0,
+                new Recall(arg0, null, strict: false),
+                this
+            );
+        }else{
+            //ebug.Log($"Parsing long form (size now {i - i0})");
+            i++; // step over 'since'
+            var arg1 = vec.Get<Expression>(i++);
+            if(!ValidateOperand(arg1)) return;
+            var op2 = vec.AsString(i);
+            bool strict = false;
+            if( op2 == "!"){
+                strict = true; i++;
+            }
+            var n = i - i0;
+            //ebug.Log($"Long form; replace {n} elements at {i}");
+            vec.Replace(i0, i - i0,
+                        new Recall(arg0, arg1, strict), this);
+        }
+    }
+
+    bool ValidateOperand(Expression arg){
+        switch(arg){
+            case Invocation:
+                return true;
+            case BinaryExp exp when exp.op == ".":
+                return true;
+            case null:
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    override public string ToString()
+    => $"RecallRule";
+
+}}}

--- a/Elk/Runtime/Basic/Parser-Details/RecallRule.cs.meta
+++ b/Elk/Runtime/Basic/Parser-Details/RecallRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03efb67b79381b44697533fe731e212a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Parser.cs
+++ b/Elk/Runtime/Basic/Parser.cs
@@ -10,7 +10,7 @@ using static Elk.Basic.Parser.RuleSet;
 namespace Elk.Basic{
 public partial class Parser : Elk.Parser{
 
-    public static bool showErrorDetails = false;
+    public static bool showErrorDetails = true;
     Rule[] rules;
     public Action log;
 
@@ -18,7 +18,8 @@ public partial class Parser : Elk.Parser{
 
     public Parser(string funcPreamble) => rules = new Rule[]{
         Rst( new FuncRule(), new FuncPrecursor(funcPreamble)),
-        Rst( ".", new InvocationRule()),
+        Rst( new RecallRule() ),
+        Rst( new AccessRule(), new InvocationRule()),
         Una("! ~ ++ -- + -"),
         Bin("* / %"),
         Bin("+ -"),

--- a/Elk/Runtime/Basic/Runner-Details/InternalFunctionBinding.cs
+++ b/Elk/Runtime/Basic/Runner-Details/InternalFunctionBinding.cs
@@ -14,9 +14,9 @@ public class InternalFunctionBinding : InvocationBinding{
     override protected object Invoke(
         object[] values, Runner<Context> ρ, Context cx
     ){
-        cx.Push(function.parameters, values);
+        cx.PushArguments(function.parameters, values);
         var @out = ρ.Eval(function.body, cx);
-        cx.Pop();
+        cx.PopArguments();
         return @out;
     }
 

--- a/Elk/Runtime/Basic/Runner-Details/RecallEval.cs
+++ b/Elk/Runtime/Basic/Runner-Details/RecallEval.cs
@@ -1,0 +1,34 @@
+using Ex = System.Exception;
+using Elk.Util;
+using Elk.Basic.Graph;
+using Elk.Memory;
+
+namespace Elk.Basic{
+public class RecallEval{
+
+    public bool Eval(Recall r, Runner ρ, Context cx){
+        var action = EvalEvent(r.action, ρ, cx);
+        var since  = r.since == null
+                     ? null : EvalEvent(r.since, ρ, cx);
+        return cx.cog.Did(action, since, r.strict, cx);
+    }
+
+    Call EvalEvent(object e, Runner ρ, Context cx){
+        switch(e){
+            case BinaryExp exp when exp.op == ".":
+                var subject = ρ.Eval(exp.arg0, cx);
+                var call = ρ.inv.Recall((Invocation)exp.arg1, ρ, cx);
+                return new Call(
+                    cx.cog.NameOf(subject, allowDefault: false),
+                    call
+                );
+            case Invocation ι:
+                return new Call("self", ρ.inv.Recall(ι, ρ, cx));
+            default:
+                throw new Ex(
+                    $"Cannot eval {e} of type {e?.GetType().Name}"
+                );
+        }
+    }
+
+}}

--- a/Elk/Runtime/Basic/Runner-Details/RecallEval.cs.meta
+++ b/Elk/Runtime/Basic/Runner-Details/RecallEval.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a88fd40b92329643aee3f108fb2cd54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Runner.cs
+++ b/Elk/Runtime/Basic/Runner.cs
@@ -10,6 +10,7 @@ public class Runner : Elk.Runner<Context>{
     public BinEval bin;
     public PropEval prp;
     public InvocationEval inv;
+    public RecallEval rec;
     public Func<object, bool> literal;
 
     public Runner(){
@@ -17,6 +18,7 @@ public class Runner : Elk.Runner<Context>{
         una = new UnaEval();
         prp = new PropEval();
         inv = new InvocationEval();
+        rec = new RecallEval();
         literal = IsLiteral;
     }
 
@@ -26,6 +28,7 @@ public class Runner : Elk.Runner<Context>{
             case UnaryExp  op: return una.Eval(op, this, cx);
             case string label: return prp.Eval(label, cx);
             case Invocation ι: return inv.Eval(ι, this, cx);
+            case Recall     r: return rec.Eval(r, this, cx);
             case object val when literal(val): return val;
             case null: return arg;
             default: throw new Ex($"Cannot evaluate {arg}");

--- a/Elk/Runtime/Extern/Externals.cs
+++ b/Elk/Runtime/Extern/Externals.cs
@@ -24,7 +24,7 @@ public static class Externals{
         foreach(var e in cx)
             if(e.Eval(label, out object @out))
                 return @out;
-        throw new Ex($"Not found ({label})");
+        throw new Ex($"Property not found: [{label}]");
     }
 
 }}

--- a/Elk/Runtime/Memory.meta
+++ b/Elk/Runtime/Memory.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2250ced2927af5744b1b2db044e6d054
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Memory/Call.cs
+++ b/Elk/Runtime/Memory/Call.cs
@@ -1,0 +1,18 @@
+namespace Elk.Memory{
+public class Call{
+
+    public string subject;
+    public string call;
+
+    public Call(string subject, string call){
+        this.subject = subject;
+        this.call = call;
+    }
+
+    public static implicit operator string(Call self)
+    => self?.ToString();
+
+    override public string ToString()
+    => $"{subject}.{call}";
+
+}}

--- a/Elk/Runtime/Memory/Call.cs.meta
+++ b/Elk/Runtime/Memory/Call.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10e83863919f6904b8d9f66f14b822e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Memory/Cog.cs
+++ b/Elk/Runtime/Memory/Cog.cs
@@ -1,0 +1,17 @@
+using Cx = Elk.Basic.Context;
+
+namespace Elk.Memory{
+public interface Cog{
+
+    // Return true if an agent have performed the specified action
+    // since 'since' has occured
+    bool Did(Call action, Call since, bool strict, Cx cx);
+
+    // Name a subject (used when committing actions to memory)
+    string NameOf(object agent, bool allowDefault);
+
+    // Called by the runtime when a function has evaluated;
+    // in this case, either record or discard the call
+    void Commit(string call, object returnValue, Record record);
+
+}}

--- a/Elk/Runtime/Memory/Cog.cs.meta
+++ b/Elk/Runtime/Memory/Cog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7a0c14aa2f75d94e92784f23ffee037
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Memory/Record.cs
+++ b/Elk/Runtime/Memory/Record.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Elk.Memory{
+// Captures actions observed by an agent, including those performed
+// by the agent itself and other agents
+public class Record{
+
+    public string name;
+    List<Frame> events = new List<Frame>(256);
+
+    public Record(string name) => this.name = name;
+
+    public bool Contains(string arg, string since, bool strict){
+        if(events.Count == 0) return false;
+        if(since == null) return Contains(arg);
+        //ebug.Log($"Check {arg} since [{since}, strict: {strict}]");
+        var found = false;
+		for(int i = events.Count - 1; i >= 0; i--){
+			if(events[i].Matches(arg)){
+				if(!strict) return true;
+				found = true;
+			}
+			if(events[i].Matches(since)) return found;
+		}
+		return false;
+    }
+
+    bool Contains(string @event){
+        //ebug.Log($"Check {@event} / ({events.Count})");
+        for(int i = events.Count - 1; i >= 0; i--){
+            if(events[i].Matches(@event)){
+                //ebug.Log($"Did match {@event}");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void Append(string @event, float time){
+        events.Add(new Frame(@event, time));
+        //ebug.Log($"{name} added {@event} at {time:0.00} ({events.Count})");
+    }
+
+    public class Frame{
+        float time;
+        string @event;
+
+        public Frame(string e, float t){
+            time = t;
+            @event = e;
+        }
+
+        public bool Matches(string arg) => @event == arg;
+
+    }
+
+}}

--- a/Elk/Runtime/Memory/Record.cs.meta
+++ b/Elk/Runtime/Memory/Record.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 751a3b7043861404081ea0f256b58c73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Util/Sequence.cs
+++ b/Elk/Runtime/Util/Sequence.cs
@@ -15,6 +15,9 @@ public class Sequence{
     public Sequence(params Token[] args)
     => elements = args.ToList();
 
+    public Sequence(params object[] args)
+    => elements = (from x in args select new Token(x, 0)).ToList();
+
     public Sequence(params string[] args)
     => elements = (from x in args select new Token(x, 0)).ToList();
 

--- a/Elk/Tests/RecallRuleTest.cs
+++ b/Elk/Tests/RecallRuleTest.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using Elk.Util;
+using UnityEngine;
+using Elk.Basic.Graph;
+
+namespace Elk_Test{
+public class RecallRuleTest{
+
+    Elk.Basic.Parser.RecallRule rule;
+
+    [SetUp] public void Setup()
+    => rule = new Elk.Basic.Parser.RecallRule();
+
+    [Test] public void Test_did(){
+        var inv = new Invocation("foo");
+        var seq = new Sequence("did", inv);
+        rule.Process(seq, 0);
+        Assert.AreEqual(1, seq.size);
+        Assert.That(seq[0] is Recall);
+    }
+
+    [Test] public void Test_did_since(){
+        var inv0 = new Invocation("foo");
+        var inv1 = new Invocation("bar");
+        var seq = new Sequence("did", inv0, "since", inv1);
+        rule.Process(seq, 0);
+        Assert.AreEqual(1, seq.size);
+        Assert.That(seq[0] is Recall);
+        var rec = (Recall)seq[0];
+        Assert.That(!rec.strict);
+    }
+
+    [Test] public void Test_did_since_strict(){
+        var inv0 = new Invocation("foo");
+        var inv1 = new Invocation("bar");
+        var seq = new Sequence("did", inv0, "since", inv1, "!");
+        rule.Process(seq, 0);
+        Assert.AreEqual(1, seq.size);
+        Assert.That(seq[0] is Recall);
+        var rec = (Recall)seq[0];
+        Assert.That(rec.strict);
+    }
+
+}}

--- a/Elk/Tests/RecallRuleTest.cs.meta
+++ b/Elk/Tests/RecallRuleTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bfa5b860790d884b885b993896a9535
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Compared with #35, allows checking tasks performed by other agents; syntax

`did X since Y`

where X and Y satisfy either `action(...)` or `agent.action(...)` - example:

`did Hit(foe) since foe.Hit(player)`

When X or Y do not satisfy the above, behavior is undefined (likely, alternative forms will be reserved/disallowed)