### PR TITLE
Enable recording actions and events

### DIFF
--- a/BT-lang/Runtime/BTL-Externals.cs
+++ b/BT-lang/Runtime/BTL-Externals.cs
@@ -10,7 +10,10 @@ public partial class BTL{
     void EvalExternals(){
         List<object> ext = new List<object>();
         foreach(var c in @import) ext.Add(c);
-        foreach(var type in requirements) ext.Add(Req(type));
+        foreach(var type in requirements){
+            if(string.IsNullOrEmpty(type)) continue;
+            ext.Add(Req(type));
+        }
         externals = ext.ToArray();
     }
 

--- a/BT-lang/Runtime/BTL.cs
+++ b/BT-lang/Runtime/BTL.cs
@@ -13,6 +13,7 @@ public partial class BTL : MonoBehaviour, LogSource{
     public Component[] @import;
     public string[] requirements;
     public bool useHistory = true;
+    public bool recordIntents = false;
     public Record record;
     public BTLCog cognition;
     //
@@ -23,6 +24,9 @@ public partial class BTL : MonoBehaviour, LogSource{
     History _history;
     bool useScene = false;
 
+    public void Record(string action, object args, status @out)
+    => cognition.CommitAction(action, args, @out, record);
+
     void Start() => EvalExternals();
 
     void Awake(){
@@ -31,6 +35,7 @@ public partial class BTL : MonoBehaviour, LogSource{
     }
 
     void Update(){
+        if(string.IsNullOrEmpty(path)) return;
         if(path != loadedFrom && IsValidPath(path)) π = null;
         var p  = program;
         var cx = BTLContextFactory.Create(
@@ -42,6 +47,7 @@ public partial class BTL : MonoBehaviour, LogSource{
     }
 
     void OnValidate(){
+        if(path == null) return;
         if(path.EndsWith(".txt")){
             path = path.Substring(0, path.Length-4);
         }
@@ -66,6 +72,11 @@ public partial class BTL : MonoBehaviour, LogSource{
         private get => π != null ? π : (π = Build(path));
         set => π = value;
     }
+
+    public System.Func<string, object> findInScene{ get{
+        var finder = GetComponent<Finder>();
+        return finder != null ? finder.FindInScene : null;
+    }}
 
     Interpreter<Cx> interpreter
     => ι != null ? ι : (ι = BTLInterpreterFactory.Create());

--- a/BT-lang/Runtime/BTL.cs
+++ b/BT-lang/Runtime/BTL.cs
@@ -13,7 +13,7 @@ public partial class BTL : MonoBehaviour, LogSource{
     public Component[] @import;
     public string[] requirements;
     public bool useHistory = true;
-    public bool recordIntents = false;
+    public bool recordIntents = true;
     public Record record;
     public BTLCog cognition;
     //

--- a/BT-lang/Runtime/BTLContextFactory.cs
+++ b/BT-lang/Runtime/BTLContextFactory.cs
@@ -15,7 +15,7 @@ public static class BTLContextFactory{
         var cx = new Context(){
             modules   = new FuncDef[][]{ module.functions },
             externals = externals,
-            domain    = useScene ? FindInScene : null,
+            domain    = useScene ? owner.findInScene : null,
             record    = owner.record,
             cog      = owner.cognition
         };

--- a/BT-lang/Runtime/Finder.cs
+++ b/BT-lang/Runtime/Finder.cs
@@ -1,0 +1,6 @@
+namespace Activ.BTL{
+public interface Finder{
+
+    object FindInScene(string arg);
+
+}}

--- a/BT-lang/Runtime/Finder.cs.meta
+++ b/BT-lang/Runtime/Finder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 605c38271ee6671429d6029e32009684
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Runner-Details/PropEval.cs
+++ b/Elk/Runtime/Basic/Runner-Details/PropEval.cs
@@ -4,8 +4,20 @@ using Elk.Bindings.CSharp;
 namespace Elk.Basic.Runtime{
 public class PropEval{
 
-    public object Eval(string label, Context cx)
-    => cx.HasKey(label) ? cx[label]
-    : cx.domain?.Invoke(label) ??  cx.externals.Eval(label);
+    public object Eval(string label, Context cx){
+        // Check internals (ELK function arguments)
+        if(cx.HasKey(label)){
+            return cx[label];
+        }
+        // Check externals
+        var @out = cx.externals.Eval(label, out bool found);
+        if(found){
+            return @out;
+        }else if(cx.domain == null){
+            throw new Ex($"Property not found: [{label}]");
+        }
+        // Check scene domain if set
+        return cx.domain.Invoke(label);
+    }
 
 }}

--- a/Elk/Runtime/Extern/ExternalFunctionBinding.cs
+++ b/Elk/Runtime/Extern/ExternalFunctionBinding.cs
@@ -3,6 +3,7 @@ using Elk.Util;
 using Elk.Basic;
 using Elk.Basic.Graph;
 using Elk.Basic.Runtime;
+using UnityEngine;
 
 namespace Elk.Bindings.CSharp{
 public class ExternalFunctionBinding : InvocationBinding{
@@ -17,6 +18,14 @@ public class ExternalFunctionBinding : InvocationBinding{
 
     override protected object Invoke(
         object[] values, Runner<Context> ρ, Context cx
-    ) => method.Invoke(target, values);
+    ){
+        try{
+            return method.Invoke(target, values);
+        }catch(TargetParameterCountException ex){
+            Debug.LogError(
+                $"Wrong param count calling {method.Name} ({values.Length})");
+            throw(ex);
+        }
+    }
 
 }}

--- a/Elk/Runtime/Extern/Externals.cs
+++ b/Elk/Runtime/Extern/Externals.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Reflection;
-using Ex = System.Exception;
 using Elk.Basic.Runtime;
 
 namespace Elk.Bindings.CSharp{
@@ -19,12 +18,14 @@ public static class Externals{
     }
 
     public static object Eval(
-        this IEnumerable cx, string label
+        this IEnumerable cx, string label, out bool found
     ){
-        foreach(var e in cx)
-            if(e.Eval(label, out object @out))
-                return @out;
-        throw new Ex($"Property not found: [{label}]");
+        foreach(var e in cx){
+            if(e.Eval(label, out object @out)){
+                found = true; return @out;
+            }
+        }
+        found = false; return null;
     }
 
 }}

--- a/Elk/Runtime/Memory/Frame.cs
+++ b/Elk/Runtime/Memory/Frame.cs
@@ -1,0 +1,13 @@
+public class Frame{
+    
+    float time;
+    string @event;
+
+    public Frame(string e, float t){
+        time = t;
+        @event = e;
+    }
+
+    public bool Matches(string arg) => @event == arg;
+
+}

--- a/Elk/Runtime/Memory/Frame.cs.meta
+++ b/Elk/Runtime/Memory/Frame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc512d35b736f4546a715dfbd619578e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Memory/Record.cs
+++ b/Elk/Runtime/Memory/Record.cs
@@ -39,20 +39,6 @@ public class Record{
 
     public void Append(string @event, float time){
         events.Add(new Frame(@event, time));
-        //ebug.Log($"{name} added {@event} at {time:0.00} ({events.Count})");
-    }
-
-    public class Frame{
-        float time;
-        string @event;
-
-        public Frame(string e, float t){
-            time = t;
-            @event = e;
-        }
-
-        public bool Matches(string arg) => @event == arg;
-
     }
 
 }}

--- a/Elk/Runtime/Util/ArrayExt.cs
+++ b/Elk/Runtime/Util/ArrayExt.cs
@@ -13,25 +13,30 @@ public static class ArrayExt{
     ).ToArray();
 
     // NOTE: concise but not so clean
+    // TODO if no good remove it
     public static string Format(this object[] arr)
     => "(" + string.Join(", ", arr) + ")";
 
-    public static string NeatFormat(this object[] arr){
+    // TODO clarity? this is mainly for
+    // rendering arguments in ELK memory record
+    public static string NeatFormat(this Array arr){
         var o = new StringBuilder();
         o.Append("(");
         var len = arr.Length;
         for(int i = 0; i < len; i++){
-            o.Append(ToCleanString(arr[i]));
+            o.Append(ToCleanString(arr.GetValue(i)));
             if(i < len -1) o.Append(", ");
         }
         o.Append(")");
         return o.ToString();
     }
 
-    static string ToCleanString(object arg){
+    // TODO clarity? this is mainly for
+    // rendering arguments in ELK memory record
+    public static string ToCleanString(object arg){
         switch(arg){
             case GameObject go: return go.name;
-            case Transform t:   return t.gameObject.name;
+            case Component c:   return c.gameObject.name;
             case null: return "null";
             default: return arg.ToString();
         }


### PR DESCRIPTION
Recorded actions and events (if done well) are more reliable than intents:

- Actions: something that an agent have actually done (or failed at); typically this is beyond the scope of the BT.
- Intent: essentially, stack traces.

Considered turning intents off by default (memory/perf overheads); however intents remain valuable since they encompass broad denominators (say, "Encounter") as opposed to fine grain actions ("Greet").

Fulfilled intents are best (only record actions, but with connex intents) but not directly an ELK issue.