### PR TITLE
Methods for tracking and recording events, fulfilled intents

### DIFF
--- a/Elk/Runtime/Basic/CallGraph.cs
+++ b/Elk/Runtime/Basic/CallGraph.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Elk.Memory;
 
 namespace Elk.Basic{
 public class CallGraph{
@@ -8,6 +9,9 @@ public class CallGraph{
     Node root;
     Stack<Node> stack = new Stack<Node>();
     public Func<object, string> returnValueFormatter;
+
+    public Elk.Stack CallStack(Cog client, Record record)
+    => new StackTrace(stack.Peek(), client, record);
 
     public void Push(string arg){
         var node = new Node(arg);
@@ -46,16 +50,18 @@ public class CallGraph{
 
     // =============================================================
 
-    class Node{
+    public class Node{
 
+        public Node parent;
         public string info;
-        public List<Node> children;
+        public List<Node> children {get; private set;}
 
         public Node(string info) => this.info = info;
 
         public void Add(Node arg){
             if(children == null) children = new List<Node>(2);
             children.Add(arg);
+            arg.parent = this;
         }
 
     }

--- a/Elk/Runtime/Basic/Context.cs
+++ b/Elk/Runtime/Basic/Context.cs
@@ -20,6 +20,8 @@ public class Context{
         graph = new CallGraph();
     }
 
+    public Elk.Stack callStack => graph.CallStack(cog, record);
+
     public object this[string key]
     => argumentStack.Peek()[key];
 
@@ -33,7 +35,7 @@ public class Context{
 
     public void StackPop(object value){
         var callInfo = graph.Peek();
-        cog.Commit(callInfo, value, record);
+        cog.CommitCall(callInfo, value, record);
         graph.Pop(value);
     }
 

--- a/Elk/Runtime/Basic/StackTrace.cs
+++ b/Elk/Runtime/Basic/StackTrace.cs
@@ -1,0 +1,25 @@
+using Elk.Memory;
+
+namespace Elk.Basic{
+public readonly struct StackTrace : Elk.Stack{
+
+    readonly CallGraph.Node tail;
+    readonly Cog client;
+    readonly Record record;
+
+    public StackTrace(CallGraph.Node tail, Cog client, Record record){
+        this.tail = tail;
+        this.client = client;
+        this.record = record;
+    }
+
+    public void Commit(object result){
+        var node = tail;
+        while(node != null){
+            var msg = node.info.Substring(2);
+            client.CommitAction(msg, result, record);
+            node = node.parent;
+        }
+    }
+
+}}

--- a/Elk/Runtime/Basic/StackTrace.cs.meta
+++ b/Elk/Runtime/Basic/StackTrace.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d05bf59e08ff15f4caec07240065ecaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Core/API.cs
+++ b/Elk/Runtime/Core/API.cs
@@ -24,4 +24,9 @@ public interface Runner<Cx>{
 
 }
 
+// For deferred/client side stack recording
+public interface Stack{
+    void Commit(object result);
+}
+
 }

--- a/Elk/Runtime/Extern/Arguments.cs
+++ b/Elk/Runtime/Extern/Arguments.cs
@@ -1,0 +1,14 @@
+using System; using System.Linq;
+
+namespace Elk.Bindings.CSharp{
+// Array exts for getting implied parameter types from arguments
+public static class Arguments{
+
+    public static Type[] ParameterTypes(
+        this object[] args, bool nullIsObj
+    ) => (
+        from x in args select x?.GetType()
+        ?? (nullIsObj ? typeof(object) : null)
+    ).ToArray();
+
+}}

--- a/Elk/Runtime/Extern/Arguments.cs.meta
+++ b/Elk/Runtime/Extern/Arguments.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa716ea12c0280a4e87329d96c3dea41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Extern/TypeExt.cs
+++ b/Elk/Runtime/Extern/TypeExt.cs
@@ -14,14 +14,14 @@ public static class TypeExt{
     ){
         var method = self.GetMethod(
             func,
-            args?.Types(nullIsObj : true) ?? NoArgs
+            args?.ParameterTypes(nullIsObj : true) ?? NoArgs
         );
         if(method != null){
             return method;
         }
         return self.FindMethod(
             func,
-            args?.Types(nullIsObj : false) ?? NoArgs
+            args?.ParameterTypes(nullIsObj : false) ?? NoArgs
         );
     }
 

--- a/Elk/Runtime/Memory/Cog.cs
+++ b/Elk/Runtime/Memory/Cog.cs
@@ -12,6 +12,8 @@ public interface Cog{
 
     // Called by the runtime when a function has evaluated;
     // in this case, either record or discard the call
-    void Commit(string call, object returnValue, Record record);
+    void CommitCall(string call, object returnValue, Record record);
+
+    void CommitAction(string call, object returnValue, Record record);
 
 }}

--- a/Elk/Runtime/Util/ArrayExt.cs
+++ b/Elk/Runtime/Util/ArrayExt.cs
@@ -6,12 +6,6 @@ using System.Text;
 namespace Elk.Util{
 public static class ArrayExt{
 
-    public static Type[] Types(this object[] arr, bool nullIsObj
-    ) => (
-        from x in arr select x?.GetType()
-        ?? (nullIsObj ? typeof(object) : null)
-    ).ToArray();
-
     // NOTE: concise but not so clean
     // TODO if no good remove it
     public static string Format(this object[] arr)

--- a/Elk/Tests/ArgumentsTest.cs
+++ b/Elk/Tests/ArgumentsTest.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using Elk.Bindings.CSharp;
+
+namespace Elk_Test{
+public class ArgumentsTest{
+
+    [Test] public void TestParameterTypes(
+        [Values(false, true)] bool nullIsObj
+    ){
+        var arr = new object[]{};
+        var types = arr.ParameterTypes(nullIsObj);
+        Assert.AreEqual(types.Length, 0);
+    }
+
+    [Test] public void TestParameterTypes_FromNullArray_Throws(){
+        object[] arr = null;
+        Assert.Throws<ArgumentNullException>(
+            () => arr.ParameterTypes(nullIsObj: false)
+        );
+    }
+
+}}

--- a/Elk/Tests/ArgumentsTest.cs.meta
+++ b/Elk/Tests/ArgumentsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00e633be916785844a75d966d8d497bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Tests/ArrayExtTest.cs
+++ b/Elk/Tests/ArrayExtTest.cs
@@ -6,19 +6,6 @@ using Elk.Util;
 namespace Elk_Test{
 public class ArrayExtTest{
 
-    [Test] public void TestTypes([Values(false, true)] bool nullIsObj){
-        var arr = new object[]{};
-        var types = arr.Types(nullIsObj);
-        Assert.AreEqual(types.Length, 0);
-    }
-
-    [Test] public void TestTypes_FromNullArray_Throws(){
-        object[] arr = null;
-        Assert.Throws<ArgumentNullException>(
-            () => arr.Types(nullIsObj: false)
-        );
-    }
-
     [Test] public void TestFormat(){
         var x = new object[]{ "a", 10, null };
         Assert.AreEqual("(a, 10, )", x.Format());


### PR DESCRIPTION
Events are custom, external to both Elk and BTL; recording events through ELK makes them available to scripting.

Fulfilled intents tie external actions to Elk/BTL stacks; good way to track what agents are doing because:
- Intents provide context to granular actions; the end of a lifelong quest (which may be one step forward, or bending to pick up an object) is a fulfilled intent.
- Fulfilled intents are material whereas pure BTL stacks are not - a `done` status may be returned in error; more commonly, the BT may stop tracking a task, which would cause done tasks to not get recorded. 
- Fulfilled intents are (comparatively) not emitted often (reduced overheads)

Re: lifelong tasks probably a little more work needed as I'm noticing statuses up the stack may not be reporting correctly (perhaps not this PR)