### PR TITLE
Enable site binding support

### DIFF
--- a/Elk/Runtime/Basic/Graph/Branch.cs
+++ b/Elk/Runtime/Basic/Graph/Branch.cs
@@ -1,0 +1,5 @@
+namespace Elk.Basic.Graph{
+public interface Branch{
+    int Count();
+    int GetChild(int index);
+}}

--- a/Elk/Runtime/Basic/Graph/Branch.cs.meta
+++ b/Elk/Runtime/Basic/Graph/Branch.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6dff00e968b659a43b6ffc1f7e93fcaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Elk/Runtime/Basic/Graph/Invocation.cs
+++ b/Elk/Runtime/Basic/Graph/Invocation.cs
@@ -8,10 +8,13 @@ public class Invocation : Expression{
     public readonly string name;
     public readonly object[] arguments;
     public readonly object[] values;
+    public readonly float id;
     public object binding;
 
-    public Invocation(string name, IEnumerable<object> arguments=null){
+    public Invocation(string name, float id,
+                      IEnumerable<object> arguments=null){
         this.name = name;
+        this.id = id;
         this.arguments = arguments?.ToArray() ?? null;
         this.values = this.arguments != null
             ? new object[this.arguments.Length] : new object[]{};

--- a/Elk/Runtime/Basic/Parser-Details/InvocationRule.cs
+++ b/Elk/Runtime/Basic/Parser-Details/InvocationRule.cs
@@ -14,7 +14,7 @@ public class InvocationRule : LocalRule{
             //ebug.Log("missing '(' parens");
             return;
         }
-        var funcName = vec.AsWord(i);
+        var funcName = vec.AsWord(i, out float id);
         if( funcName == null){
             //ebug.Log($"no func name found: [{funcName}]");
             return;
@@ -47,7 +47,7 @@ public class InvocationRule : LocalRule{
         }
         //ebug.Log($"rep count {repCount}");
         vec.Replace(i0, repCount, new Invocation(
-            funcName, arguments
+            funcName, id, arguments
         ), this);
     }
 

--- a/Elk/Runtime/Basic/Runner.cs
+++ b/Elk/Runtime/Basic/Runner.cs
@@ -21,7 +21,7 @@ public class Runner : Elk.Runner<Context>{
     }
 
     public object Invoke(string func, Context cx)
-    => Eval(new Invocation(func), cx);
+    => Eval(new Invocation(func, id: 0f), cx);
 
     public object Eval(object arg, Context cx){
         switch(arg){

--- a/Elk/Runtime/Basic/Tokenizer.cs
+++ b/Elk/Runtime/Basic/Tokenizer.cs
@@ -15,17 +15,19 @@ public class Tokenizer : Elk.Tokenizer{
         var xchars = commentParser.Parse(arg);
         // NOTE - when a word is formed its line number is the same
         // as the next character's.
-        int line = 1;
+        int line = 0;
+        int offset = 0;
         foreach(xchar c in xchars){
             line = c.line;
+            offset = c.offset;
             if(char.IsWhiteSpace(c) || char.IsControl(c)){
                 if(word.Length > 0){
-                    tokens.Add(word, line);
+                    tokens.Add(word, line, offset);
                     word = new StringBuilder();
                 }
             }else if (char.IsLetterOrDigit(c)){
                 if(word.Length > 0 && IsBreaking(word[word.Length-1])){
-                    tokens.Add(word, line);
+                    tokens.Add(word, line, offset);
                     word = new StringBuilder();
                 }
                 word.Append(c);
@@ -34,13 +36,13 @@ public class Tokenizer : Elk.Tokenizer{
                 // is an error, however... +=, -=, ...
                 if(!(Double(c, word) || IsDecimalDot(c, word)
                                      || IsArrowHead(c, word))){
-                    tokens.Add(word, line);
+                    tokens.Add(word, line, offset);
                     word = new StringBuilder();
                 }
                 word.Append(c);
             }
         }
-        if(word.Length > 0) tokens.Add(word, line);
+        if(word.Length > 0) tokens.Add(word, line, offset);
         return tokens.ToArray();
     }
 

--- a/Elk/Runtime/Core/Token.cs
+++ b/Elk/Runtime/Core/Token.cs
@@ -2,11 +2,15 @@ namespace Elk{
 public class Token{
 
     public int line;
+    public int offset;
+    public float id;
     public object content;
 
-    public Token(object content, int line){
+    public Token(object content, int line, int offset){
         this.content = content;
         this.line    = line;
+        this.offset  = offset;
+        this.id      = float.Parse($"{line}.{offset}");
     }
 
     public static explicit operator string(Token self)

--- a/Elk/Runtime/Util/ListExt.cs
+++ b/Elk/Runtime/Util/ListExt.cs
@@ -6,15 +6,18 @@ namespace Elk.Util{
 public static class ListExt{
 
     public static void Add(
-        this List<Token> self, StringBuilder s, int line
+        this List<Token> self, StringBuilder s, int line, int offset
     ){
-        self.Add(new Token(s.ToString(), line));
+        self.Add(new Token(s.ToString(), line, offset));
     }
 
     public static string[] ToStringArray(this IEnumerable<Token> self)
     => (from t in self select t.content.ToString()).ToArray();
 
-    public static int Line(this List<Token> self, int index)
+    public static int LineNumber(this List<Token> self, int index)
     => self[index].line;
+
+    public static int LineOffset(this List<Token> self, int index)
+    => self[index].offset;
 
 }}

--- a/Elk/Runtime/Util/Sequence.cs
+++ b/Elk/Runtime/Util/Sequence.cs
@@ -15,11 +15,12 @@ public class Sequence{
     public Sequence(params Token[] args)
     => elements = args.ToList();
 
+    // TODO minimally offset should increase
     public Sequence(params object[] args)
-    => elements = (from x in args select new Token(x, 0)).ToList();
+    => elements = (from x in args select new Token(x, 0, 0)).ToList();
 
     public Sequence(params string[] args)
-    => elements = (from x in args select new Token(x, 0)).ToList();
+    => elements = (from x in args select new Token(x, 0, 0)).ToList();
 
     public static implicit operator Sequence(string[] args)
     => new Sequence(args);
@@ -60,10 +61,24 @@ public class Sequence{
 
     public string AsString(int index) => Get(index) as string;
 
+    public string AsWord(int index, out float id){
+        id = Id(index);
+        var str = AsString(index);
+        if(str == null) return null;
+        return char.IsLetter(str[0]) ? str : null;
+    }
+
     public string AsWord(int index){
         var str = AsString(index);
         if(str == null) return null;
         return char.IsLetter(str[0]) ? str : null;
+    }
+
+    public float Id(int index){
+        switch(Get(index)){
+            case Token token: return token.id;
+            default: return -1f;
+        }
     }
 
     public object Get(int index)
@@ -74,7 +89,9 @@ public class Sequence{
     => (index > lastIndex || index < 0) ? null
        : this[index] as T;
 
-    public int LineNumber(int index) => elements.Line(index);
+    public int LineNumber(int index) => elements.LineNumber(index);
+
+    public int LineOffset(int index) => elements.LineOffset(index);
 
     public T[] ReadSeveral<T>(ref int index) where T : class{
         List<T> @out = null;
@@ -92,9 +109,10 @@ public class Sequence{
     // NOTE last arg here only for logging purposes
     public void Replace(int i, int count, object arg, object src){
         log?.Invoke($"Replace [{count}] tokens at index {i} via {src}");
-        var lineNum = LineNumber(i);
+        var lineNum    = LineNumber(i);
+        var lineOffset = LineOffset(i);
         elements.RemoveRange(i, count);
-        elements.Insert(i, new Token(arg, lineNum));
+        elements.Insert(i, new Token(arg, lineNum, lineOffset));
         dirty = true;
     }
 

--- a/Elk/Tests/RecallRuleTest.cs
+++ b/Elk/Tests/RecallRuleTest.cs
@@ -12,7 +12,7 @@ public class RecallRuleTest{
     => rule = new Elk.Basic.Parser.RecallRule();
 
     [Test] public void Test_did(){
-        var inv = new Invocation("foo");
+        var inv = new Invocation("foo", 0f);
         var seq = new Sequence("did", inv);
         rule.Process(seq, 0);
         Assert.AreEqual(1, seq.size);
@@ -20,8 +20,8 @@ public class RecallRuleTest{
     }
 
     [Test] public void Test_did_since(){
-        var inv0 = new Invocation("foo");
-        var inv1 = new Invocation("bar");
+        var inv0 = new Invocation("foo", 0f);
+        var inv1 = new Invocation("bar", 0f);
         var seq = new Sequence("did", inv0, "since", inv1);
         rule.Process(seq, 0);
         Assert.AreEqual(1, seq.size);
@@ -31,8 +31,8 @@ public class RecallRuleTest{
     }
 
     [Test] public void Test_did_since_strict(){
-        var inv0 = new Invocation("foo");
-        var inv1 = new Invocation("bar");
+        var inv0 = new Invocation("foo", 0f);
+        var inv1 = new Invocation("bar", 0f);
         var seq = new Sequence("did", inv0, "since", inv1, "!");
         rule.Process(seq, 0);
         Assert.AreEqual(1, seq.size);

--- a/Legal.meta
+++ b/Legal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d29735c9c00b6a3488c031c7fac09f95
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Legal/Legal-FAQ.md.meta
+++ b/Legal/Legal-FAQ.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af9e8a9e66759f84887414fd9e18f1f9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Requirement here is for each `Invocation` to have a unique id.
Current version iffy, should probably enable graph traversal and use that instead and enforce unique ids in linked programs.