### PR TITLE
Add `Wait(duration)` function

### DIFF
--- a/BT-lang/Runtime/BTL-BinEval.cs
+++ b/BT-lang/Runtime/BTL-BinEval.cs
@@ -59,8 +59,22 @@ public class BinEval : Elk.Basic.Runtime.BinEval{
         throw new RtEx($"Unimplemented op {op}");
     }
 
-    status ToStatus(object arg)
-    => arg is status s ? s : arg is bool b ? (status)b
-    : throw new RtEx($"Don't know how to convert {arg.Format()} to status");
+    status ToStatus(object arg){
+        switch(arg){
+            case status x:    return x;
+            case impending x: return (status)x;
+            case pending x:   return (status)x;
+            case bool x:      return (status)x;
+            case failure x:   return (status)x;
+            case action x:    return (status)x;
+            case loop x:      return (status)x;
+            default:
+                throw new RtEx(
+                    $"Don't know how to convert {arg.Format()} to status"
+                );
+        }
+    }
+    //=> arg is status s ? s : arg is bool b ? (status)b
+//: ;
 
 }}

--- a/BT-lang/Runtime/BTL-GraphFormatter.cs
+++ b/BT-lang/Runtime/BTL-GraphFormatter.cs
@@ -12,6 +12,8 @@ public class GraphFormatter : CallGraph.Formatter{
                 return ReturnValue(value) + " " + name;
             case bool:
                 return ReturnValue(value) + " " + name;
+            case null:
+                return name + " : " + null;
             default:
                 return name + " : " + value.ToString();
         }

--- a/BT-lang/Runtime/BTL.cs
+++ b/BT-lang/Runtime/BTL.cs
@@ -46,6 +46,14 @@ public partial class BTL : MonoBehaviour, LogSource{
 
     // -------------------------------------------------------------
 
+    public action Wait(float duration){
+        this.enabled = false;
+        Invoke("Resume", duration);
+        return @void();
+    }
+
+    public void Resume() => this.enabled = true;
+
     public void Hold(bool flag, object src){
         if(!sparse){ suspend = false; return; }
         if(flag){

--- a/BT-lang/Runtime/BTLCog.cs
+++ b/BT-lang/Runtime/BTLCog.cs
@@ -18,7 +18,10 @@ public class BTLCog : Cog{
 
     public bool Did(
         Call @event, Call since, bool strict, Context cx
-    ) => cx.record.Contains(@event, since, strict);
+    ){
+        //ebug.Log($"Did {@event} since:{since}?");
+        return cx.record.Contains(@event, since, strict);
+    }
 
     // Called by elk runtime to submit function calls
     public void CommitCall(string call, object output, Record record){
@@ -77,6 +80,8 @@ public class BTLCog : Cog{
                 return go.name;
             case Component co:
                 return co.gameObject.name;
+            case string str:
+                return str;
             case null:
                 return "self";
             default:

--- a/DPE/Editor/DPEWindow.cs
+++ b/DPE/Editor/DPEWindow.cs
@@ -41,22 +41,34 @@ public partial class DPEWindow : EditorWindow{
         foreach(var field in fields){
             Set set = (Set)field.value;
             string setLogFmt = "-";
+            string valueFmt = "";
             if(set != null){
                 if(set.value != null){
-                    var entry = set.log.Find(
-                        x => x.entity == set.value
-                    );
-                    setLogFmt = LogFormat.FormatLogEntry(entry);
+                    valueFmt = FormatValue(set);
+                    if(!Application.isPlaying){
+                        var entry = set.log.Find(
+                            x => x.entity == set.value
+                        );
+                        setLogFmt = LogFormat.FormatLogEntry(entry)+"\n";
+                    }
                 }else{
-                    setLogFmt = LogFormat.FormatBestMatch(set.log);
+                    if(!Application.isPlaying){
+                        setLogFmt = LogFormat.FormatBestMatch(set.log);
+                    }
                 }
             }
-            fieldstr += $"{field.name}:\n{setLogFmt}\n\n";
+            fieldstr += $"{field.name}: "
+                     +  valueFmt
+                     +  $"{setLogFmt}\n";
         }
         //
         return targetName + DS
              + perceived  + DS
              + fieldstr;
+    }
+
+    string FormatValue(Set set){
+        return $"{set.value}\n";
     }
 
     void OnGUI(){


### PR DESCRIPTION
- `BTL.Wait(seconds)` pauses the BT; `BTL.Resume()` can be called to wake up the BT early; does not interact with suspending the BT.
- Binary evals now support certainties (bugfix)
- Graph formatter would break with null prop values (bugfix)
- Call recorder (narrative memory) allows literal names
- DPE window format fixes