### PR TITLE
Add option to bump a client when exiting hold

### DIFF
--- a/BT-lang/Runtime/BTL.cs
+++ b/BT-lang/Runtime/BTL.cs
@@ -63,7 +63,10 @@ public partial class BTL : MonoBehaviour, LogSource{
         if(!sparse){ vars.suspend = false; return; }
         if(flag){
             vars.suspend = true;
+            //OnHold?.Invoke(this);
         }else{
+            var h = GetComponent<HoldListener>();
+            h.Bump(this);
             vars.suspend = false;
         }
     }

--- a/BT-lang/Runtime/HoldListener.cs
+++ b/BT-lang/Runtime/HoldListener.cs
@@ -1,0 +1,5 @@
+public interface HoldListener{
+
+    void Bump(object src);
+
+}

--- a/BT-lang/Runtime/HoldListener.cs.meta
+++ b/BT-lang/Runtime/HoldListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45341d866a29941499292a71ff8f0e75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Bumping clients before exiting hold avoids re-entering cosmetic tasks.