### PR TITLE
Work pri op

### DIFF
--- a/BT-lang/Runtime/BTL-BinEval.cs
+++ b/BT-lang/Runtime/BTL-BinEval.cs
@@ -42,6 +42,7 @@ public class BinEval : Elk.Basic.Runtime.BinEval{
     object EvalBool(string op, bool X, object right,
                                Runner ρ, Context cx){
         switch(op){
+            case "::": return ToStatus(ρ.Eval(right, cx));
             case "||": return !X ? ToStatus(ρ.Eval(right, cx)) : done;
             case "&&": return  X ? ToStatus(ρ.Eval(right, cx)) : fail;
         }
@@ -53,6 +54,7 @@ public class BinEval : Elk.Basic.Runtime.BinEval{
     object EvalStatus(string op, status X, object right,
                              Runner ρ, Context cx){
         switch(op){
+            case "::": return X.running ? X : ToStatus(ρ.Eval(right, cx));
             case "||": return X.failing  ? ToStatus(ρ.Eval(right, cx)) : X;
             case "&&": return X.complete ? ToStatus(ρ.Eval(right, cx)) : X;
         }

--- a/Elk/Runtime/Basic/Parser/Parser.cs
+++ b/Elk/Runtime/Basic/Parser/Parser.cs
@@ -28,7 +28,7 @@ public partial class Parser : Elk.Parser{
         Bin("< > <= >="),
         Bin("== !="),
         Bin("| &"),
-        Bin("|| &&"),
+        Bin("|| && ::"),
         Rst( new ParensRule() ),
         Rst( new ModuleRule() )
     };

--- a/Elk/Runtime/Basic/Parser/Tokenizer.cs
+++ b/Elk/Runtime/Basic/Parser/Tokenizer.cs
@@ -6,7 +6,7 @@ namespace Elk.Basic{
 public class Tokenizer : Elk.Tokenizer{
 
     public char decimalDot = '.';
-    public string doubleSymbols = "+-&|=";
+    public string doubleSymbols = "+-&|=:";
     CommentParser commentParser = new CommentParser();
 
     public Token[] Tokenize(string arg){


### PR DESCRIPTION
Alongside the sequence and selector the work priority operator has the following behavior, assuming `x :: y`

- If x is done, return x
- if x is failing, return x
- if x is cont evaluate and return y

Useful in prioritizing activities, where:

- Some activities have higher priority than others
- If an agent cannot (fail) or need not (done) engage in a subtask, work should be allocated to the next subtask.